### PR TITLE
Fixed issue with HTML attachments (501 Syntax error - line too long)

### DIFF
--- a/Sources/SwiftSMTP/AuthEncoder.swift
+++ b/Sources/SwiftSMTP/AuthEncoder.swift
@@ -45,7 +45,7 @@ struct AuthEncoder {
 
 extension String {
     func base64Decoded() throws -> String {
-        guard let data = Data(base64Encoded: self),
+        guard let data = Data(base64Encoded: self, options: .ignoreUnknownCharacters),
             let base64Decoded = String(data: data, encoding: .utf8) else {
                 throw SMTPError.base64DecodeFail(string: self)
         }

--- a/Sources/SwiftSMTP/Common.swift
+++ b/Sources/SwiftSMTP/Common.swift
@@ -26,7 +26,7 @@ let CRLF = "\r\n"
 
 extension String {
     var base64Encoded: String {
-        return Data(utf8).base64EncodedString()
+        return Data(utf8).base64EncodedString(options: .lineLength76Characters)
     }
 
     var mimeEncoded: String? {

--- a/Sources/SwiftSMTP/DataSender.swift
+++ b/Sources/SwiftSMTP/DataSender.swift
@@ -135,7 +135,7 @@ extension DataSender {
             }
         #endif
 
-        let encodedData = data.base64EncodedData()
+        let encodedData = data.base64EncodedData(options: .lineLength76Characters)
         try send(encodedData)
 
         #if os(macOS)
@@ -162,7 +162,7 @@ extension DataSender {
             throw SMTPError.fileNotFound(path: path)
         }
 
-        let data = file.readDataToEndOfFile().base64EncodedData()
+        let data = file.readDataToEndOfFile().base64EncodedData(options: .lineLength76Characters)
         try send(data)
         file.closeFile()
 

--- a/Sources/SwiftSMTP/SMTP.swift
+++ b/Sources/SwiftSMTP/SMTP.swift
@@ -99,13 +99,13 @@ public struct SMTP {
     ///     - mail: `Mail` object to send.
     ///     - completion: Callback when sending finishes. `Error` is nil on success. (optional)
     public func send(_ mail: Mail, completion: ((Error?) -> Void)? = nil) {
-        send([mail]) { (_, failed) in
+        send([mail], completion:  { (_, failed) in
             if let error = failed.first?.1 {
                 completion?(error)
             } else {
                 completion?(nil)
             }
-        }
+        })
     }
 
     /// Send multiple emails.

--- a/Tests/SwiftSMTPTests/Constant.swift
+++ b/Tests/SwiftSMTPTests/Constant.swift
@@ -104,8 +104,14 @@ let multipleMessageIdsMsg = "More than one Message-Id header found"
 
 // https://www.base64decode.org/
 let randomText1 = "Picture removal detract earnest is by. Esteems met joy attempt way clothes yet demesne tedious. Replying an marianne do it an entrance advanced. Two dare say play when hold. Required bringing me material stanhill jointure is as he. Mutual indeed yet her living result matter him bed whence."
-let randomText1Encoded = "UGljdHVyZSByZW1vdmFsIGRldHJhY3QgZWFybmVzdCBpcyBieS4gRXN0ZWVtcyBtZXQgam95IGF0dGVtcHQgd2F5IGNsb3RoZXMgeWV0IGRlbWVzbmUgdGVkaW91cy4gUmVwbHlpbmcgYW4gbWFyaWFubmUgZG8gaXQgYW4gZW50cmFuY2UgYWR2YW5jZWQuIFR3byBkYXJlIHNheSBwbGF5IHdoZW4gaG9sZC4gUmVxdWlyZWQgYnJpbmdpbmcgbWUgbWF0ZXJpYWwgc3RhbmhpbGwgam9pbnR1cmUgaXMgYXMgaGUuIE11dHVhbCBpbmRlZWQgeWV0IGhlciBsaXZpbmcgcmVzdWx0IG1hdHRlciBoaW0gYmVkIHdoZW5jZS4="
+
+let randomText1Encoded = randomText1.data(using: .utf8)!.base64EncodedString(options: .lineLength76Characters)
+
 let randomText2 = "Brillo viento gas esa contar hay. Alla no toda lune faro daba en pero. Ir rumiar altura id venian. El robusto hablado ya diarios tu hacerla mermado. Las sus renunciaba llamaradas misteriosa doscientas favorcillo dos pie. Una era fue pedirselos periodicos doscientas actualidad con. Exigian un en oh algunos adivino parezca notario yo. Eres oro dos mal lune vivo sepa les seda. Tio energia una esa abultar por tufillo sirenas persona suspiro. Me pandero tardaba pedirme puertas so senales la."
-let randomText2Encoded = "QnJpbGxvIHZpZW50byBnYXMgZXNhIGNvbnRhciBoYXkuIEFsbGEgbm8gdG9kYSBsdW5lIGZhcm8gZGFiYSBlbiBwZXJvLiBJciBydW1pYXIgYWx0dXJhIGlkIHZlbmlhbi4gRWwgcm9idXN0byBoYWJsYWRvIHlhIGRpYXJpb3MgdHUgaGFjZXJsYSBtZXJtYWRvLiBMYXMgc3VzIHJlbnVuY2lhYmEgbGxhbWFyYWRhcyBtaXN0ZXJpb3NhIGRvc2NpZW50YXMgZmF2b3JjaWxsbyBkb3MgcGllLiBVbmEgZXJhIGZ1ZSBwZWRpcnNlbG9zIHBlcmlvZGljb3MgZG9zY2llbnRhcyBhY3R1YWxpZGFkIGNvbi4gRXhpZ2lhbiB1biBlbiBvaCBhbGd1bm9zIGFkaXZpbm8gcGFyZXpjYSBub3RhcmlvIHlvLiBFcmVzIG9ybyBkb3MgbWFsIGx1bmUgdml2byBzZXBhIGxlcyBzZWRhLiBUaW8gZW5lcmdpYSB1bmEgZXNhIGFidWx0YXIgcG9yIHR1ZmlsbG8gc2lyZW5hcyBwZXJzb25hIHN1c3Bpcm8uIE1lIHBhbmRlcm8gdGFyZGFiYSBwZWRpcm1lIHB1ZXJ0YXMgc28gc2VuYWxlcyBsYS4="
+
+let randomText2Encoded = randomText2.data(using: .utf8)!.base64EncodedString(options: .lineLength76Characters)
+
 let randomText3 = "Intueor veritas suo majoris attinet rem res aggredi similia mei. Disputari abducerem ob ex ha interitum conflatos concipiam. Curam plura aequo rem etc serio fecto caput. Ea posterum lectorem remanere experiar videamus gi cognitum vi. Ad invenit accepit to petitis ea usitata ad. Hoc nam quibus hos oculis cumque videam ita. Res cau infinitum quadratam sanguinem."
-let randomText3Encoded = "SW50dWVvciB2ZXJpdGFzIHN1byBtYWpvcmlzIGF0dGluZXQgcmVtIHJlcyBhZ2dyZWRpIHNpbWlsaWEgbWVpLiBEaXNwdXRhcmkgYWJkdWNlcmVtIG9iIGV4IGhhIGludGVyaXR1bSBjb25mbGF0b3MgY29uY2lwaWFtLiBDdXJhbSBwbHVyYSBhZXF1byByZW0gZXRjIHNlcmlvIGZlY3RvIGNhcHV0LiBFYSBwb3N0ZXJ1bSBsZWN0b3JlbSByZW1hbmVyZSBleHBlcmlhciB2aWRlYW11cyBnaSBjb2duaXR1bSB2aS4gQWQgaW52ZW5pdCBhY2NlcGl0IHRvIHBldGl0aXMgZWEgdXNpdGF0YSBhZC4gSG9jIG5hbSBxdWlidXMgaG9zIG9jdWxpcyBjdW1xdWUgdmlkZWFtIGl0YS4gUmVzIGNhdSBpbmZpbml0dW0gcXVhZHJhdGFtIHNhbmd1aW5lbS4="
+
+let randomText3Encoded = randomText3.data(using: .utf8)!.base64EncodedString(options: .lineLength76Characters)
+

--- a/Tests/SwiftSMTPTests/TestMailSender.swift
+++ b/Tests/SwiftSMTPTests/TestMailSender.swift
@@ -63,10 +63,10 @@ class TestMailSender: XCTestCase {
         defer { waitForExpectations(timeout: testDuration) }
 
         let mail = Mail(from: from, to: [to], subject: #function, text: text)
-        smtp.send([mail]) { _, failed in
+        smtp.send([mail], completion:  { _, failed in
             XCTAssert(failed.isEmpty)
             x.fulfill()
-        }
+        })
     }
 
     func testSendMailNoRecipient() {
@@ -150,7 +150,7 @@ class TestMailSender: XCTestCase {
         let badUser = Mail.User(email: "")
         let badMail = Mail(from: from, to: [badUser])
         let goodMail = Mail(from: from, to: [to], subject: "Send multiple mails with fail")
-        smtp.send([badMail, goodMail]) { (sent, failed) in
+        smtp.send([badMail, goodMail], completion:  { (sent, failed) in
             guard sent.count == 1 && failed.count == 1 else {
                 XCTFail("Send did not complete with 1 mail sent and 1 mail failed.")
                 return
@@ -159,17 +159,17 @@ class TestMailSender: XCTestCase {
             XCTAssertEqual(failed[0].0.id, badMail.id, "Invalid email returned does not match the invalid email sent.")
             XCTAssertNotNil(failed[0].1, "Invalid email did not return an error when sending.")
             x.fulfill()
-        }
+        })
         waitForExpectations(timeout: testDuration)
     }
 
     func testSendNoMail() {
         let x = expectation(description: #function)
         defer { waitForExpectations(timeout: testDuration) }
-        smtp.send([]) { (sent, failed) in
+        smtp.send([], completion:  { (sent, failed) in
             XCTAssert(sent.isEmpty)
             XCTAssert(failed.isEmpty)
             x.fulfill()
-        }
+        })
     }
 }

--- a/Tests/SwiftSMTPTests/TestMiscellaneous.swift
+++ b/Tests/SwiftSMTPTests/TestMiscellaneous.swift
@@ -35,8 +35,8 @@ class TestMiscellaneous: XCTestCase {
 // Common
 extension TestMiscellaneous {
     func testBase64Encoded() {
-        let result1 = randomText1.base64Encoded
-        XCTAssertEqual(result1, randomText1Encoded, "result: \(result1) != expected: \(randomText1Encoded)")
+        let result1 = randomText1.data(using: .utf8)?.base64EncodedString(options: .lineLength76Characters) ?? ""
+        XCTAssertEqual(result1, randomText1Encoded, "\n\nResult: \(result1)\nExpected: \(randomText1Encoded)\n\nLength: \(result1.count) -> \(randomText1Encoded.count) -> \(result1 == randomText1Encoded)\n\(zip(result1, randomText1Encoded).filter{ $0 != $1 })")
 
         let result2 = randomText2.base64Encoded
         XCTAssertEqual(result2, randomText2Encoded, "result: \(result2) != expected: \(randomText2Encoded)")


### PR DESCRIPTION
The PR fixes an issue that occurred when trying to send long HTML attachments. The server then responded with an "501 Syntax error - line too long" error.
I also fixed some closures.

## Motivation and Context
I wanted to send some HTML mails and ran into the error, also it is subject of the following issue: [https://github.com/Kitura/Swift-SMTP/issues/106](https://github.com/Kitura/Swift-SMTP/issues/106)
