### PR TITLE
Fix a little RFC5321 syntax unconformance

### DIFF
--- a/Sources/SwiftSMTP/Command.swift
+++ b/Sources/SwiftSMTP/Command.swift
@@ -44,8 +44,8 @@ enum Command {
             }
         case .authUser(let user): return user
         case .authPassword(let password): return password
-        case .mail(let from): return "MAIL FROM: <\(from)>"
-        case .rcpt(let to): return "RCPT TO: <\(to)>"
+        case .mail(let from): return "MAIL FROM:<\(from)>"
+        case .rcpt(let to): return "RCPT TO:<\(to)>"
         case .data: return "DATA"
         case .dataEnd: return "\(CRLF)."
         case .quit: return "QUIT"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
I removed the additional spaces in two email commands

## Motivation and Context

The description of the Mail transaction as provided in the [RFC5321](https://tools.ietf.org/html/rfc5321#section-3.3) does not specify a space after the `MAIL FROM:` and `RCPT TO:` commands.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
This changes were tested with an instance of the dovecot submission server, that previously refused the client commands.
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have submitted a [CLA form](https://github.com/IBM-Swift/CLA)
- [x] If applicable, I have updated the documentation accordingly.
- [x] If applicable, I have added tests to cover my changes.
